### PR TITLE
Auto reorder Tabs when ItemsSource is ObservableCollection<>

### DIFF
--- a/ChromeTabs/ChromeTabControl.cs
+++ b/ChromeTabs/ChromeTabControl.cs
@@ -570,9 +570,11 @@ DependencyProperty.Register("AddTabCommandParameter", typeof(object), typeof(Chr
                 return;
             if (!fromItem.IsPinned && toItem.IsPinned)
                 return;
+
+            var tabReorder = new TabReorder(fromIndex, toIndex);
             if (this.ReorderTabsCommand != null)
             {
-                this.ReorderTabsCommand.Execute(new TabReorder(fromIndex, toIndex));
+                this.ReorderTabsCommand.Execute(tabReorder);
             }
 
             for (int i = 0; i < this.Items.Count; i += 1)
@@ -581,6 +583,9 @@ DependencyProperty.Register("AddTabCommandParameter", typeof(object), typeof(Chr
                 v.Margin = new Thickness(0);
             }
             this.SelectedItem = fromTab;
+
+            if (!tabReorder.ReorderSource)
+                return;
 
             var sourceType = ItemsSource.GetType();
             if (sourceType.IsGenericType)

--- a/ChromeTabs/ChromeTabControl.cs
+++ b/ChromeTabs/ChromeTabControl.cs
@@ -581,6 +581,17 @@ DependencyProperty.Register("AddTabCommandParameter", typeof(object), typeof(Chr
                 v.Margin = new Thickness(0);
             }
             this.SelectedItem = fromTab;
+
+            var sourceType = ItemsSource.GetType();
+            if (sourceType.IsGenericType)
+            {
+                var sourceDefinition = sourceType.GetGenericTypeDefinition();
+                if (sourceDefinition == typeof(ObservableCollection<>))
+                {
+                    var method = sourceType.GetMethod("Move");
+                    method.Invoke(ItemsSource, new object[] { fromIndex, toIndex });
+                }
+            }
         }
 
         internal void SetCanAddTab(bool value)

--- a/ChromeTabs/TabReorder.cs
+++ b/ChromeTabs/TabReorder.cs
@@ -9,10 +9,12 @@ namespace ChromeTabs
     {
         public int FromIndex { get; set; }
         public int ToIndex { get; set; }
-        public TabReorder(int from, int to)
+        public bool ReorderSource { get; set; }
+        public TabReorder(int from, int to, bool reorderSource = true)
         {
             this.FromIndex = from;
             this.ToIndex = to;
+            this.ReorderSource = reorderSource;
         }
     }
 }


### PR DESCRIPTION
I added a auto reorder if the ItemsSource is ObservableCollection<>. The User don't need to write a ReorderTabsCommand and keep the TabOrder on the Tab.
It didn't seems to work in the Demo and i don't know why, but in my Application it works like intended.