### PR TITLE
Changing AddTabCommand results in null pointer exception

### DIFF
--- a/ChromeTabs/ChromeTabControl.cs
+++ b/ChromeTabs/ChromeTabControl.cs
@@ -105,7 +105,7 @@ namespace ChromeTabs
             }
             if (e.OldValue != null)
             {
-                ICommand command = (ICommand)e.NewValue;
+                ICommand command = (ICommand)e.OldValue;
                 command.CanExecuteChanged -= ct.Command_CanExecuteChanged;
             }
         }


### PR DESCRIPTION
When setting a bound AddTabCommand to null, a null pointer exception occurs. This PR should fix that.

**In version: 1.3.4**

**Reproduction:** 
1) create chrome tab control
2) create a ICommand command in a view model
3) bind AddTabCommand to that command
4) set the ICommand to null in the view model
5) Error is triggered
