### PR TITLE
Allow setting the width and height of the add tab button

### DIFF
--- a/ChromeTabs/ChromeTabControl.cs
+++ b/ChromeTabs/ChromeTabControl.cs
@@ -423,6 +423,24 @@ DependencyProperty.Register("AddTabCommandParameter", typeof(object), typeof(Chr
             panel?.SetAddButtonControlTemplate(e.NewValue as ControlTemplate);
         }
 
+        public double AddTabButtonWidth
+        {
+            get => (double)GetValue(AddTabButtonWidthProperty);
+            set => SetValue(AddTabButtonWidthProperty, value);
+        }
+        
+        public static readonly DependencyProperty AddTabButtonWidthProperty =
+            DependencyProperty.Register("AddTabButtonWidth", typeof(double), typeof(ChromeTabControl), new PropertyMetadata(20.0));
+        
+        public double AddTabButtonHeight
+        {
+            get => (double)GetValue(AddTabButtonHeightProperty);
+            set => SetValue(AddTabButtonHeightProperty, value);
+        }
+        
+        public static readonly DependencyProperty AddTabButtonHeightProperty =
+            DependencyProperty.Register("AddTabButtonHeight", typeof(double), typeof(ChromeTabControl), new PropertyMetadata(12.0));
+
         static ChromeTabControl()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(ChromeTabControl), new FrameworkPropertyMetadata(typeof(ChromeTabControl)));

--- a/ChromeTabs/ChromeTabPanel.cs
+++ b/ChromeTabs/ChromeTabPanel.cs
@@ -63,7 +63,6 @@ namespace ChromeTabs
         private Point _downTabBoundsPoint;
         private ChromeTabControl _parent;
         private Rect _addButtonRect;
-        private Size _addButtonSize;
         private Button _addButton;
         private DateTime _lastMouseDown;
         private object _lockObject = new object();
@@ -108,7 +107,6 @@ namespace ChromeTabs
             ComponentResourceKey key = new ComponentResourceKey(typeof(ChromeTabPanel), "addButtonStyle");
             Style addButtonStyle = (Style)FindResource(key);
             _addButton = new Button { Style = addButtonStyle };
-            _addButtonSize = new Size(20, 12);
             this.Loaded += ChromeTabPanel_Loaded;
             this.Unloaded += ChromeTabPanel_Unloaded;
         }
@@ -183,9 +181,9 @@ namespace ChromeTabs
                 element.Arrange(new Rect(offset, 0, tabWidth, finalSize.Height - thickness));
                 offset += tabWidth - Overlap;
             }
-            if (ParentTabControl.IsAddButtonVisible)
-            {
-                _addButtonRect = new Rect(new Point(offset + Overlap, (finalSize.Height - _addButtonSize.Height) / 2), _addButtonSize);
+            if (ParentTabControl.IsAddButtonVisible) {
+                var addButtonSize = new Size(ParentTabControl.AddTabButtonWidth, ParentTabControl.AddTabButtonHeight);
+                _addButtonRect = new Rect(new Point(offset + Overlap, (finalSize.Height - addButtonSize.Height) / 2), addButtonSize);
                 _addButton.Arrange(_addButtonRect);
             }
             return finalSize;
@@ -214,8 +212,9 @@ namespace ChromeTabs
             }
             if (ParentTabControl.IsAddButtonVisible)
             {
-                _addButton.Measure(_addButtonSize);
-                resultSize.Width += _addButtonSize.Width;
+                var addButtonSize = new Size(ParentTabControl.AddTabButtonWidth, ParentTabControl.AddTabButtonHeight);
+                _addButton.Measure(addButtonSize);
+                resultSize.Width += addButtonSize.Width;
             }
             return resultSize;
         }

--- a/ChromeTabs/ChromeTabPanel.cs
+++ b/ChromeTabs/ChromeTabPanel.cs
@@ -387,12 +387,12 @@ namespace ChromeTabs
             Point nowPoint = p;
             if (ParentTabControl != null && ParentTabControl.IsAddButtonVisible && IsAddButtonEnabled)
             {
-                if (_addButtonRect.Contains(nowPoint) && IsAddButtonEnabled)
+                if (_addButtonRect.Contains(nowPoint))
                 {
                     _addButton.Background = ParentTabControl.AddTabButtonMouseOverBrush;
                     InvalidateVisual();
                 }
-                else if (!_addButtonRect.Contains(nowPoint) && IsAddButtonEnabled)
+                else
                 {
                     _addButton.Background = ParentTabControl.AddTabButtonBrush;
                     InvalidateVisual();
@@ -506,6 +506,13 @@ namespace ChromeTabs
         protected override void OnMouseLeave(MouseEventArgs e)
         {
             base.OnMouseLeave(e);
+            
+            if (ParentTabControl != null && ParentTabControl.IsAddButtonVisible && IsAddButtonEnabled)
+            {
+                _addButton.Background = ParentTabControl.AddTabButtonBrush;
+                InvalidateVisual();
+            }
+            
             if (_draggedTab != null && Mouse.LeftButton != MouseButtonState.Pressed && !_isReleasingTab)
             {
                 Point p = e.GetPosition(this);

--- a/Demo/CustomStyleExampleWindow.xaml
+++ b/Demo/CustomStyleExampleWindow.xaml
@@ -308,6 +308,8 @@
         <ct:ChromeTabControl  x:Name="MyChromeTabControlWithCustomStyle"
                               AddTabButtonMouseOverBrush="Orange"
                               AddTabButtonMouseDownBrush="Red"
+                              AddTabButtonWidth="20"
+                              AddTabButtonHeight="24"
                               SelectedTabBrush="WhiteSmoke"
                               TabOverlap="0"
                               Background="AliceBlue"


### PR DESCRIPTION
Related to: #38

Adds the ability to override the default width and height `(20, 12)` of the addTabButton.

```
 <ct:ChromeTabControl AddTabButtonWidth="30" AddTabButtonHeight="24"/>
```

Additionally, I noticed that sometimes for the addTabButton, the background mouseover color wasn't reset when mouse left. Added extra background color reset on the MouseLeave event.

